### PR TITLE
🔧 chore: add meta tag indexing

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,7 +10,10 @@ import "@styles/global.css";
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <!-- <link rel="icon" type="image/svg+xml" href="/favicon.svg" /> -->
-
+    <meta
+      name="google-site-verification"
+      content="2IYFmQ6DR-zpbLsNpMWAZL0ukBhgdKrxM3mw9lIvAw0"
+    />
     <title>Diled - Smart Home</title>
   </head>
   <body>


### PR DESCRIPTION
This pull request includes a small but important change to the `src/layouts/Layout.astro` file. The change adds a Google site verification meta tag to the head of the HTML document.

* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L13-R16): Added a Google site verification meta tag for SEO purposes.